### PR TITLE
fix parsing of boostrap prop names

### DIFF
--- a/_create_templates.py
+++ b/_create_templates.py
@@ -321,8 +321,8 @@ def get_role_colors(rule_props):
 
     # Override with role colors for current theme
     for prop, val in rule_props[":root"].items():
-        if prop.startswith("--"):
-            maybe_color = prop.lstrip("--bs-")
+        if prop.startswith("--bs-"):
+            maybe_color = prop[5:]
             if maybe_color in role_colors:
                 role_colors[maybe_color] = val
 


### PR DESCRIPTION
Noticed a small bug when trying to apply your code to our in-house Bootstrap template.

Currently, `lstrip("--bs-")` does not strip the exact string but all matching *characters* from the left. Thus `--bs-secondary` is parsed to `econdary` and will never match the lookup for desired role colors. On our end I simply resorted to stripping the appropriate *number* of characters from the left.

Cheers
Oliver