### PR TITLE
fix: Refactor aio_theme_switch.py to use Union type for themes parameter

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,9 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3 :: Only
     Topic :: Scientific/Engineering :: Visualization
 
 [options]

--- a/src/aio/aio_theme_switch.py
+++ b/src/aio/aio_theme_switch.py
@@ -1,3 +1,4 @@
+fron typing import Union
 from dash import html, dcc, Input, Output, clientside_callback, MATCH, ClientsideFunction, get_app, State
 from dash_bootstrap_templates import load_figure_template
 import dash_bootstrap_components as dbc
@@ -32,7 +33,7 @@ class ThemeSwitchAIO(html.Div):
     def __init__(
             self,
             aio_id: str = str(uuid.uuid4()),
-            themes: tuple[str, str] | list[str] = (dbc.themes.CYBORG, dbc.themes.BOOTSTRAP),
+            themes: Union[tuple[str, str], list[str]] = (dbc.themes.CYBORG, dbc.themes.BOOTSTRAP),
             icons=None,
             switch_props: dict[str, any] = None,
     ):


### PR DESCRIPTION
- This PR fixes #30 by:
   - Refactoring the `aio_theme_switch.py` file to use the `Union` type for the `themes` parameter.
   - Updating the `setup.cfg` file to include Python classifiers for Python 3.10 and 3.11.